### PR TITLE
Extend C# sample - : Support sharing secret with a user

### DIFF
--- a/csharp/CommandLineOptions.cs
+++ b/csharp/CommandLineOptions.cs
@@ -20,7 +20,10 @@ namespace encryptonize
     [Verb("put", HelpText = "Put a new value for the given key")]
     class PutOptions : Options
     {
-        [Option('g', "group", Required = false, HelpText = "An optional group ID for sharing the secret within a group.")]
+        [Option('u', "user", SetName = "user", Required = false, HelpText = "An optional user ID for sharing the secret with a user.")]
+        public string User { get; set; }
+
+        [Option('g', "group", SetName = "group", Required = false, HelpText = "An optional group ID for sharing the secret within a group.")]
         public string Group { get; set; }
 
         [Value(0, MetaName = "keyAndValue", Required = true, HelpText = "Key and value in the form key:value")]

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -78,10 +78,11 @@ namespace encryptonize
             }
 
             /// <summary>Encrypt given data using the /enc endpoint.</summary>
-            public async Task<byte[]> Encrypt(byte[] data, string groupId)
+            public async Task<byte[]> Encrypt(byte[] data, string userId, string groupId)
             {
                 // If present, add the group identifier to the call
                 var urlParams = "";
+                if (userId != null) { urlParams = "?uid=" + userId; }
                 if (groupId != null) { urlParams = "?gid=" + groupId; }
 
                 return await CallBinary("enc" + urlParams, data);
@@ -138,7 +139,7 @@ namespace encryptonize
 
             // We create the API client and use it to encrypt the binary value (either for ourselves or for any group)
             Client client = new Client(options.Token);
-            var cipher = await client.Encrypt(bValue, options.Group);
+            var cipher = await client.Encrypt(bValue, options.User, options.Group);
 
             // Something went wrong during encryption
             if (cipher == null) {


### PR DESCRIPTION
This PR adds an additional commandline parameter for sharing a secret with another user.

Note: This parameter is mutually exclusive with the `group` parameter, just like they are on the REST API. The code in `Program.cs` is written with this in mind, hence no additional checks to make sure both are not set. Not the prettiest, but it's only sample code anyways. :grin: